### PR TITLE
rename conflicting class name notifications

### DIFF
--- a/css/sass/styles.scss
+++ b/css/sass/styles.scss
@@ -3243,7 +3243,7 @@ h1.join-donate {
   }
 }
 
-.notifications {
+.app-notifications-icon {
   @include make-col(0.5);
   display: flex;
   justify-content: center;


### PR DESCRIPTION
as previously stated, the classname is in conflict with at 3rd party vendor in which we cannot override the vendors classname setting.

I have changed it to a more unique name.